### PR TITLE
Updated the metadata.json files to edit the TypeLinks section.

### DIFF
--- a/src/Android/Xamarin.Android/Samples/Data/FeatureLayerQuery/metadata.json
+++ b/src/Android/Xamarin.Android/Samples/Data/FeatureLayerQuery/metadata.json
@@ -9,7 +9,7 @@
   "RequiresLocalServer":false,
   "Image":"FeatureLayerQuery.jpg",
   "Link":"",
-  "TypeLink": ["T:Esri.ArcGISRuntime.Data.FeatureTable","T:Esri.ArcGISRuntime.Data.FeatureQueryResult","T:Esri.ArcGISRuntime.Data.QueryParameters","M:Esri.ArcGISRuntime.Data.FeatureTable.QueryFeaturesAsync(Esri.ArcGISRuntime.Data.QueryParameters)","P:Esri.ArcGISRuntime.Data.QueryParameters.WhereClause"
+  "TypeLink": ["T:Esri.ArcGISRuntime.Data.FeatureQueryResult","T:Esri.ArcGISRuntime.Data.QueryParameters","M:Esri.ArcGISRuntime.Data.FeatureTable.QueryFeaturesAsync(Esri.ArcGISRuntime.Data.QueryParameters)","P:Esri.ArcGISRuntime.Data.QueryParameters.WhereClause"
   ],
   "SampleFolder": "FeatureLayerQuery"
 }

--- a/src/Android/Xamarin.Android/Samples/Data/ServiceFeatureTableManualCache/metadata.json
+++ b/src/Android/Xamarin.Android/Samples/Data/ServiceFeatureTableManualCache/metadata.json
@@ -9,7 +9,7 @@
   "RequiresLocalServer":false,
   "Image":"ServiceFeatureTableManualCache.jpg",
   "Link":"",
-  "TypeLink": ["P:Esri.ArcGISRuntime.Data.ServiceFeatureTable.FeatureRequestMode","E:Esri.ArcGISRuntime.Data.FeatureTable.LoadStatusChanged","M:Esri.ArcGISRuntime.Data.ServiceFeatureTable.PopulateFromServiceAsync(Esri.ArcGISRuntime.Data.QueryParameters,System.Boolean,System.Collections.Generic.IEnumerable{System.String})"
+  "TypeLink": ["E:Esri.ArcGISRuntime.Data.FeatureTable.LoadStatusChanged","M:Esri.ArcGISRuntime.Data.ServiceFeatureTable.PopulateFromServiceAsync(Esri.ArcGISRuntime.Data.QueryParameters,System.Boolean,System.Collections.Generic.IEnumerable{System.String})"
   ],
   "SampleFolder": "ServiceFeatureTableManualCache"
 }

--- a/src/Android/Xamarin.Android/Samples/Data/ServiceFeatureTableNoCache/metadata.json
+++ b/src/Android/Xamarin.Android/Samples/Data/ServiceFeatureTableNoCache/metadata.json
@@ -9,7 +9,7 @@
   "RequiresLocalServer":false,
   "Image":"ServiceFeatureTableNoCache.jpg",
   "Link":"",
-  "TypeLink": ["T:Esri.ArcGISRuntime.Data.FeatureRequestMode","P:Esri.ArcGISRuntime.Data.ServiceFeatureTable.FeatureRequestMode"
+  "TypeLink": ["T:Esri.ArcGISRuntime.Data.FeatureRequestMode"
   ],
   "SampleFolder": "ServiceFeatureTableNoCache"
 }

--- a/src/Android/Xamarin.Android/Samples/Map/ChangeBasemap/metadata.json
+++ b/src/Android/Xamarin.Android/Samples/Map/ChangeBasemap/metadata.json
@@ -9,7 +9,7 @@
   "RequiresLocalServer":false,
   "Image":"ChangeBasemap.jpg",
   "Link":"",
-  "TypeLink": ["P:Esri.ArcGISRuntime.Mapping.Map.Basemap","M:Esri.ArcGISRuntime.Mapping.Basemap.CreateTopographic","M:Esri.ArcGISRuntime.Mapping.Basemap.CreateStreets","M:Esri.ArcGISRuntime.Mapping.Basemap.CreateImagery","M:Esri.ArcGISRuntime.Mapping.Basemap.CreateOceans"
+  "TypeLink": ["M:Esri.ArcGISRuntime.Mapping.Basemap.CreateTopographic","M:Esri.ArcGISRuntime.Mapping.Basemap.CreateStreets","M:Esri.ArcGISRuntime.Mapping.Basemap.CreateImagery","M:Esri.ArcGISRuntime.Mapping.Basemap.CreateOceans"
   ],
  "SampleFolder":  "ChangeBasemap"
 }

--- a/src/Android/Xamarin.Android/Samples/Map/DisplayMap/metadata.json
+++ b/src/Android/Xamarin.Android/Samples/Map/DisplayMap/metadata.json
@@ -9,7 +9,7 @@
   "RequiresLocalServer":false,
   "Image":"DisplayMap.jpg",
   "Link":"",
-  "TypeLink": ["T:Esri.ArcGISRuntime.Mapping.Map","M:Esri.ArcGISRuntime.Mapping.Basemap.CreateImagery"
+  "TypeLink": ["P:Esri.ArcGISRuntime.Mapping.Map.Basemap"
   ],
   "SampleFolder": "DisplayMap"
 }

--- a/src/Android/Xamarin.Android/Samples/Map/SetInitialMapArea/metadata.json
+++ b/src/Android/Xamarin.Android/Samples/Map/SetInitialMapArea/metadata.json
@@ -9,7 +9,7 @@
   "RequiresLocalServer":false,
   "Image":"SetInitialMapArea.jpg",
   "Link":"",
-  "TypeLink": ["T:Esri.ArcGISRuntime.Mapping.Viewpoint","P:Esri.ArcGISRuntime.Mapping.Map.InitialViewpoint"
+  "TypeLink": ["P:Esri.ArcGISRuntime.Mapping.Map.InitialViewpoint"
   ],
   "SampleFolder": "SetInitialMapArea"
 }

--- a/src/Forms/Shared/Samples/Data/FeatureLayerQuery/metadata.json
+++ b/src/Forms/Shared/Samples/Data/FeatureLayerQuery/metadata.json
@@ -9,7 +9,7 @@
   "RequiresLocalServer":false,
   "Image":"FeatureLayerQuery.jpg",
   "Link":"",
-  "TypeLink": ["T:Esri.ArcGISRuntime.Data.FeatureTable","T:Esri.ArcGISRuntime.Data.FeatureQueryResult","T:Esri.ArcGISRuntime.Data.QueryParameters","M:Esri.ArcGISRuntime.Data.FeatureTable.QueryFeaturesAsync(Esri.ArcGISRuntime.Data.QueryParameters)","P:Esri.ArcGISRuntime.Data.QueryParameters.WhereClause"
+  "TypeLink": ["T:Esri.ArcGISRuntime.Data.FeatureQueryResult","T:Esri.ArcGISRuntime.Data.QueryParameters","M:Esri.ArcGISRuntime.Data.FeatureTable.QueryFeaturesAsync(Esri.ArcGISRuntime.Data.QueryParameters)","P:Esri.ArcGISRuntime.Data.QueryParameters.WhereClause"
   ],
   "SampleFolder": "FeatureLayerQuery"
 }

--- a/src/Forms/Shared/Samples/Data/ServiceFeatureTableManualCache/metadata.json
+++ b/src/Forms/Shared/Samples/Data/ServiceFeatureTableManualCache/metadata.json
@@ -9,7 +9,7 @@
   "RequiresLocalServer":false,
   "Image":"ServiceFeatureTableManualCache.jpg",
   "Link":"",
-  "TypeLink": ["P:Esri.ArcGISRuntime.Data.ServiceFeatureTable.FeatureRequestMode","E:Esri.ArcGISRuntime.Data.FeatureTable.LoadStatusChanged","M:Esri.ArcGISRuntime.Data.ServiceFeatureTable.PopulateFromServiceAsync(Esri.ArcGISRuntime.Data.QueryParameters,System.Boolean,System.Collections.Generic.IEnumerable{System.String})"
+  "TypeLink": ["E:Esri.ArcGISRuntime.Data.FeatureTable.LoadStatusChanged","M:Esri.ArcGISRuntime.Data.ServiceFeatureTable.PopulateFromServiceAsync(Esri.ArcGISRuntime.Data.QueryParameters,System.Boolean,System.Collections.Generic.IEnumerable{System.String})"
   ],
   "SampleFolder": "ServiceFeatureTableManualCache"
 }

--- a/src/Forms/Shared/Samples/Data/ServiceFeatureTableNoCache/metadata.json
+++ b/src/Forms/Shared/Samples/Data/ServiceFeatureTableNoCache/metadata.json
@@ -9,7 +9,7 @@
   "RequiresLocalServer":false,
   "Image":"ServiceFeatureTableNoCache.jpg",
   "Link":"",
-  "TypeLink": ["T:Esri.ArcGISRuntime.Data.FeatureRequestMode","P:Esri.ArcGISRuntime.Data.ServiceFeatureTable.FeatureRequestMode"
+  "TypeLink": ["T:Esri.ArcGISRuntime.Data.FeatureRequestMode"
   ],
   "SampleFolder": "ServiceFeatureTableNoCache"
 }

--- a/src/Forms/Shared/Samples/Map/ChangeBasemap/metadata.json
+++ b/src/Forms/Shared/Samples/Map/ChangeBasemap/metadata.json
@@ -9,7 +9,7 @@
   "RequiresLocalServer":false,
   "Image":"ChangeBasemap.jpg",
   "Link":"",
-  "TypeLink": ["P:Esri.ArcGISRuntime.Mapping.Map.Basemap","M:Esri.ArcGISRuntime.Mapping.Basemap.CreateTopographic","M:Esri.ArcGISRuntime.Mapping.Basemap.CreateStreets","M:Esri.ArcGISRuntime.Mapping.Basemap.CreateImagery","M:Esri.ArcGISRuntime.Mapping.Basemap.CreateOceans"
+  "TypeLink": ["M:Esri.ArcGISRuntime.Mapping.Basemap.CreateTopographic","M:Esri.ArcGISRuntime.Mapping.Basemap.CreateStreets","M:Esri.ArcGISRuntime.Mapping.Basemap.CreateImagery","M:Esri.ArcGISRuntime.Mapping.Basemap.CreateOceans"
   ],
   "SampleFolder": "ChangeBasemap"
 }

--- a/src/Forms/Shared/Samples/Map/DisplayMap/metadata.json
+++ b/src/Forms/Shared/Samples/Map/DisplayMap/metadata.json
@@ -9,7 +9,7 @@
   "RequiresLocalServer":false,
   "Image":"DisplayMap.jpg",
   "Link":"",
-  "TypeLink": ["T:Esri.ArcGISRuntime.Mapping.Map","M:Esri.ArcGISRuntime.Mapping.Basemap.CreateImagery"
+  "TypeLink": ["P:Esri.ArcGISRuntime.Mapping.Map.Basemap"
   ],
   "SampleFolder": "DisplayMap"
 }

--- a/src/Forms/Shared/Samples/Map/SetInitialMapArea/metadata.json
+++ b/src/Forms/Shared/Samples/Map/SetInitialMapArea/metadata.json
@@ -9,7 +9,7 @@
   "RequiresLocalServer":false,
   "Image":"SetInitialMapArea.jpg",
   "Link":"",
-  "TypeLink": ["T:Esri.ArcGISRuntime.Mapping.Viewpoint","P:Esri.ArcGISRuntime.Mapping.Map.InitialViewpoint"
+  "TypeLink": ["P:Esri.ArcGISRuntime.Mapping.Map.InitialViewpoint"
   ],
   "SampleFolder": "SetInitialMapArea"
 }

--- a/src/iOS/Xamarin.iOS/Samples/Data/FeatureLayerQuery/metadata.json
+++ b/src/iOS/Xamarin.iOS/Samples/Data/FeatureLayerQuery/metadata.json
@@ -9,7 +9,7 @@
   "RequiresLocalServer":false,
   "Image":"FeatureLayerQuery.jpg",
   "Link":"",
-  "TypeLink": ["T:Esri.ArcGISRuntime.Data.FeatureTable","T:Esri.ArcGISRuntime.Data.FeatureQueryResult","T:Esri.ArcGISRuntime.Data.QueryParameters","M:Esri.ArcGISRuntime.Data.FeatureTable.QueryFeaturesAsync(Esri.ArcGISRuntime.Data.QueryParameters)","P:Esri.ArcGISRuntime.Data.QueryParameters.WhereClause"
+  "TypeLink": ["T:Esri.ArcGISRuntime.Data.FeatureQueryResult","T:Esri.ArcGISRuntime.Data.QueryParameters","M:Esri.ArcGISRuntime.Data.FeatureTable.QueryFeaturesAsync(Esri.ArcGISRuntime.Data.QueryParameters)","P:Esri.ArcGISRuntime.Data.QueryParameters.WhereClause"
   ],
   "SampleFolder": "FeatureLayerQuery"
 }

--- a/src/iOS/Xamarin.iOS/Samples/Data/ServiceFeatureTableManualCache/metadata.json
+++ b/src/iOS/Xamarin.iOS/Samples/Data/ServiceFeatureTableManualCache/metadata.json
@@ -9,7 +9,7 @@
   "RequiresLocalServer":false,
   "Image":"ServiceFeatureTableManualCache.jpg",
   "Link":"",
-  "TypeLink": ["P:Esri.ArcGISRuntime.Data.ServiceFeatureTable.FeatureRequestMode","E:Esri.ArcGISRuntime.Data.FeatureTable.LoadStatusChanged","M:Esri.ArcGISRuntime.Data.ServiceFeatureTable.PopulateFromServiceAsync(Esri.ArcGISRuntime.Data.QueryParameters,System.Boolean,System.Collections.Generic.IEnumerable{System.String})"
+  "TypeLink": ["E:Esri.ArcGISRuntime.Data.FeatureTable.LoadStatusChanged","M:Esri.ArcGISRuntime.Data.ServiceFeatureTable.PopulateFromServiceAsync(Esri.ArcGISRuntime.Data.QueryParameters,System.Boolean,System.Collections.Generic.IEnumerable{System.String})"
   ],
   "SampleFolder": "ServiceFeatureTableManualCache"
 }

--- a/src/iOS/Xamarin.iOS/Samples/Data/ServiceFeatureTableNoCache/metadata.json
+++ b/src/iOS/Xamarin.iOS/Samples/Data/ServiceFeatureTableNoCache/metadata.json
@@ -9,7 +9,7 @@
   "RequiresLocalServer":false,
   "Image":"ServiceFeatureTableNoCache.jpg",
   "Link":"",
-  "TypeLink": ["T:Esri.ArcGISRuntime.Data.FeatureRequestMode","P:Esri.ArcGISRuntime.Data.ServiceFeatureTable.FeatureRequestMode"
+  "TypeLink": ["T:Esri.ArcGISRuntime.Data.FeatureRequestMode"
   ],
   "SampleFolder": "ServiceFeatureTableNoCache"
 }

--- a/src/iOS/Xamarin.iOS/Samples/Layers/FeatureLayerSelection/metadata.json
+++ b/src/iOS/Xamarin.iOS/Samples/Layers/FeatureLayerSelection/metadata.json
@@ -9,7 +9,7 @@
   "RequiresLocalServer":false,
   "Image":"FeatureLayerSelection.jpg",
   "Link":"",
-  "TypeLink": ["T:Esri.ArcGISRuntime.Mapping.SelectionMode","T:Esri.ArcGISRuntime.Data.QueryParameters","P:Esri.ArcGISRuntime.Mapping.FeatureLayer.SelectionColor","P:Esri.ArcGISRuntime.Mapping.FeatureLayer.SelectionWidth","M:Esri.ArcGISRuntime.Mapping.FeatureLayer.SelectFeaturesAsync(Esri.ArcGISRuntime.Data.QueryParameters,Esri.ArcGISRuntime.Mapping.SelectionMode)"
+  "TypeLink": ["T:Esri.ArcGISRuntime.Mapping.SelectionMode","P:Esri.ArcGISRuntime.Mapping.FeatureLayer.SelectionColor","P:Esri.ArcGISRuntime.Mapping.FeatureLayer.SelectionWidth","M:Esri.ArcGISRuntime.Mapping.FeatureLayer.SelectFeaturesAsync(Esri.ArcGISRuntime.Data.QueryParameters,Esri.ArcGISRuntime.Mapping.SelectionMode)"
   ],
   "SampleFolder": "FeatureLayerSelection"
 }

--- a/src/iOS/Xamarin.iOS/Samples/Map/ChangeBasemap/metadata.json
+++ b/src/iOS/Xamarin.iOS/Samples/Map/ChangeBasemap/metadata.json
@@ -9,7 +9,7 @@
   "RequiresLocalServer":false,
   "Image":"ChangeBasemap.jpg",
   "Link":"",
-  "TypeLink": ["P:Esri.ArcGISRuntime.Mapping.Map.Basemap","M:Esri.ArcGISRuntime.Mapping.Basemap.CreateTopographic","M:Esri.ArcGISRuntime.Mapping.Basemap.CreateStreets","M:Esri.ArcGISRuntime.Mapping.Basemap.CreateImagery","M:Esri.ArcGISRuntime.Mapping.Basemap.CreateOceans"
+  "TypeLink": ["M:Esri.ArcGISRuntime.Mapping.Basemap.CreateTopographic","M:Esri.ArcGISRuntime.Mapping.Basemap.CreateStreets","M:Esri.ArcGISRuntime.Mapping.Basemap.CreateImagery","M:Esri.ArcGISRuntime.Mapping.Basemap.CreateOceans"
   ],
   "SampleFolder": "ChangeBasemap"
 }

--- a/src/iOS/Xamarin.iOS/Samples/Map/DisplayMap/metadata.json
+++ b/src/iOS/Xamarin.iOS/Samples/Map/DisplayMap/metadata.json
@@ -9,7 +9,7 @@
   "RequiresLocalServer":false,
   "Image":"DisplayMap.jpg",
   "Link":"",
-  "TypeLink": ["T:Esri.ArcGISRuntime.Mapping.Map","M:Esri.ArcGISRuntime.Mapping.Basemap.CreateImagery"
+  "TypeLink": ["P:Esri.ArcGISRuntime.Mapping.Map.Basemap"
   ],
   "SampleFolder": "DisplayMap"
 }

--- a/src/iOS/Xamarin.iOS/Samples/Map/SetInitialMapArea/metadata.json
+++ b/src/iOS/Xamarin.iOS/Samples/Map/SetInitialMapArea/metadata.json
@@ -9,7 +9,7 @@
   "RequiresLocalServer":false,
   "Image":"SetInitialMapArea.jpg",
   "Link":"",
-  "TypeLink": ["T:Esri.ArcGISRuntime.Mapping.Viewpoint","P:Esri.ArcGISRuntime.Mapping.Map.InitialViewpoint"
+  "TypeLink": ["P:Esri.ArcGISRuntime.Mapping.Map.InitialViewpoint"
   ],
   "SampleFolder": "SetInitialMapArea"
 }


### PR DESCRIPTION
At this point in the LibRefAPI builds, we need to only showcase one code example per TYPE page. When multiple code examples can be nested in the 'EXAMPLES' chevron we will can loosen the restriction. Currently, multiple 'EXAMPLES' sections get generated when more that one sample is listed across the metadata.json files. 